### PR TITLE
fix: 修复 GitHub Pages 重定向问题并添加部署指南

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -1,0 +1,193 @@
+# GitHub Pages 部署指南
+
+## 问题诊断结果
+
+访问 `wuxiansen.github.io` 跳转到 README.md 内容的原因:
+
+1. **gh-pages 分支不存在** - VuePress 构建产物应该部署到此分支
+2. **GitHub Pages 配置可能指向了错误的源** - 应该指向 `gh-pages` 分支
+3. **自动部署 workflow 可能从未成功运行**
+
+## 解决方案
+
+### 方案一:手动触发部署 (推荐)
+
+#### 步骤 1: 检查 GitHub Actions 权限
+
+1. 进入仓库 Settings → Actions → General
+2. 确保以下设置:
+   - **Actions permissions**: 选择 "Allow all actions and reusable workflows"
+   - **Workflow permissions**: 选择 "Read and write permissions"
+   - ✅ 勾选 "Allow GitHub Actions to create and approve pull requests"
+
+#### 步骤 2: 检查 GitHub Pages 配置
+
+1. 进入仓库 Settings → Pages
+2. **Source** 设置:
+   - Branch: `gh-pages`
+   - Folder: `/ (root)`
+3. 点击 Save
+
+如果看不到 `gh-pages` 分支选项,这是正常的,执行步骤 3 后会自动创建。
+
+#### 步骤 3: 手动触发部署
+
+有两种方式触发部署:
+
+**方式 A: 通过 GitHub 网页界面**
+
+1. 进入仓库的 Actions 标签页
+2. 点击左侧的 "部署文档" workflow
+3. 点击右侧的 "Run workflow" 按钮
+4. 选择 `main` 分支
+5. 点击绿色的 "Run workflow" 按钮
+
+**方式 B: 推送代码到 main 分支**
+
+```bash
+# 切换到 main 分支
+git checkout main
+
+# 拉取最新代码
+git pull origin main
+
+# 推送到 main 分支会自动触发部署
+git push origin main
+```
+
+**方式 C: 使用便捷脚本 (如果你有 GitHub CLI)**
+
+```bash
+bash script/trigger-deploy.sh
+```
+
+#### 步骤 4: 等待部署完成
+
+1. 在 Actions 标签页查看部署进度
+2. 部署成功后,会自动创建 `gh-pages` 分支
+3. 等待 1-2 分钟让 GitHub Pages 生效
+4. 访问 `wuxiansen.github.io` 查看效果
+
+### 方案二:检查是否存在部署失败
+
+1. 进入 Actions 标签页
+2. 查看是否有失败的 workflow 运行记录
+3. 如果有失败记录,点击查看错误日志
+4. 常见问题:
+   - **PAT_TOKEN 未配置**: 进入 Settings → Secrets and variables → Actions,添加名为 `PAT_TOKEN` 的 secret
+   - **pnpm 版本问题**: 检查 workflow 中的 pnpm 版本是否正确
+   - **依赖安装失败**: 检查网络问题或依赖配置
+
+### 方案三:本地构建和部署 (高级)
+
+如果自动部署一直失败,可以尝试本地构建:
+
+```bash
+# 1. 安装依赖
+pnpm install
+
+# 2. 构建项目
+pnpm build
+
+# 3. 进入构建产物目录
+cd src/.vuepress/dist
+
+# 4. 初始化 git 并推送到 gh-pages
+git init
+git add -A
+git commit -m 'deploy'
+git push -f git@github.com:wuxiansen/wuxiansen.github.io.git main:gh-pages
+
+# 5. 返回项目根目录
+cd -
+```
+
+## 验证部署成功
+
+部署成功后,访问 `https://wuxiansen.github.io`,应该能看到:
+
+- ✅ VuePress 主题的博客首页
+- ✅ 正确的导航栏和侧边栏
+- ✅ 文章列表和内容
+
+而不是:
+
+- ❌ README.md 的纯文本内容
+
+## 后续维护
+
+### 自动部署
+
+配置成功后,每次推送代码到 `main` 分支都会自动触发部署:
+
+```bash
+git add .
+git commit -m "update: 更新文章"
+git push origin main
+```
+
+### 手动部署
+
+如果需要手动触发部署(例如只想部署特定分支):
+
+```bash
+# 使用 GitHub CLI
+gh workflow run auto-deploy.yml -f branch=main -f environment=production
+
+# 或使用便捷脚本
+bash script/trigger-deploy.sh
+```
+
+## 故障排查
+
+### 问题 1: Actions 标签页为空
+
+**原因**: GitHub Actions 未启用
+
+**解决**:
+1. Settings → Actions → General
+2. 选择 "Allow all actions and reusable workflows"
+
+### 问题 2: 部署成功但网站未更新
+
+**原因**: GitHub Pages 缓存或配置问题
+
+**解决**:
+1. 等待 5-10 分钟
+2. 清除浏览器缓存
+3. 检查 Settings → Pages 配置是否正确
+4. 使用无痕模式访问网站
+
+### 问题 3: 部署失败 - PAT_TOKEN 错误
+
+**原因**: Personal Access Token 未配置或权限不足
+
+**解决**:
+1. 访问 https://github.com/settings/tokens
+2. 创建新 token,权限选择:
+   - ✅ repo (Full control of private repositories)
+   - ✅ workflow (Update GitHub Action workflows)
+3. 复制 token
+4. Settings → Secrets and variables → Actions
+5. 创建名为 `PAT_TOKEN` 的 secret,粘贴 token
+
+### 问题 4: 构建失败 - 内存不足
+
+**原因**: VuePress 构建需要较大内存
+
+**解决**: workflow 中已配置 `NODE_OPTIONS: --max_old_space_size=8192`,通常不会有此问题。如果仍然失败,可以:
+1. 检查是否有过大的图片或资源文件
+2. 优化 VuePress 配置
+
+## 相关文件
+
+- `.github/workflows/deploy-docs.yml` - 自动部署 workflow (推送触发)
+- `.github/workflows/auto-deploy.yml` - 手动部署 workflow
+- `src/.vuepress/config.ts` - VuePress 配置
+- `package.json` - 构建脚本配置
+
+## 参考文档
+
+- [VuePress 部署文档](https://v2.vuepress.vuejs.org/zh/guide/deployment.html)
+- [GitHub Pages 文档](https://docs.github.com/en/pages)
+- [GitHub Actions 文档](https://docs.github.com/en/actions)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Oragekk's Blog - 正在部署</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            color: #fff;
+            padding: 1rem;
+        }
+
+        .container {
+            text-align: center;
+            max-width: 800px;
+            width: 100%;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+            animation: fadeInUp 1s ease;
+        }
+
+        @media (max-width: 768px) {
+            h1 {
+                font-size: 2rem;
+            }
+        }
+
+        .subtitle {
+            font-size: 1.2rem;
+            margin-bottom: 2rem;
+            opacity: 0.9;
+            animation: fadeInUp 1s ease 0.2s backwards;
+        }
+
+        .card {
+            background: rgba(255, 255, 255, 0.1);
+            backdrop-filter: blur(10px);
+            border-radius: 15px;
+            padding: 2rem;
+            margin-bottom: 2rem;
+            animation: fadeInUp 1s ease 0.4s backwards;
+            text-align: left;
+        }
+
+        .card h2 {
+            font-size: 1.5rem;
+            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .card p, .card li {
+            margin-bottom: 1rem;
+            line-height: 1.8;
+            opacity: 0.95;
+        }
+
+        .card ul {
+            margin-left: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .card code {
+            background: rgba(0, 0, 0, 0.3);
+            padding: 0.2rem 0.5rem;
+            border-radius: 3px;
+            font-family: 'Courier New', monospace;
+        }
+
+        .spinner {
+            width: 50px;
+            height: 50px;
+            margin: 1rem auto;
+            border: 4px solid rgba(255, 255, 255, 0.3);
+            border-top-color: #fff;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+
+        .steps {
+            text-align: left;
+            margin-top: 1rem;
+        }
+
+        .step {
+            background: rgba(0, 0, 0, 0.2);
+            padding: 1rem;
+            border-radius: 8px;
+            margin-bottom: 1rem;
+        }
+
+        .step-number {
+            display: inline-block;
+            width: 30px;
+            height: 30px;
+            line-height: 30px;
+            text-align: center;
+            background: rgba(255, 255, 255, 0.3);
+            border-radius: 50%;
+            margin-right: 0.5rem;
+            font-weight: bold;
+        }
+
+        .links {
+            animation: fadeInUp 1s ease 0.6s backwards;
+            margin-top: 2rem;
+        }
+
+        .links a {
+            display: inline-block;
+            margin: 0.5rem;
+            padding: 0.75rem 1.5rem;
+            background: rgba(255, 255, 255, 0.2);
+            color: #fff;
+            text-decoration: none;
+            border-radius: 8px;
+            transition: all 0.3s ease;
+            border: 2px solid rgba(255, 255, 255, 0.3);
+        }
+
+        .links a:hover {
+            background: rgba(255, 255, 255, 0.3);
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+        }
+
+        .primary-btn {
+            background: rgba(255, 255, 255, 0.3) !important;
+            font-weight: bold;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        @keyframes fadeInUp {
+            from {
+                opacity: 0;
+                transform: translateY(30px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        .footer {
+            margin-top: 2rem;
+            font-size: 0.9rem;
+            opacity: 0.8;
+            animation: fadeInUp 1s ease 0.8s backwards;
+        }
+
+        .warning {
+            background: rgba(255, 193, 7, 0.2);
+            border-left: 4px solid #ffc107;
+            padding: 1rem;
+            border-radius: 4px;
+            margin-bottom: 1rem;
+        }
+
+        .success {
+            background: rgba(76, 175, 80, 0.2);
+            border-left: 4px solid #4caf50;
+            padding: 1rem;
+            border-radius: 4px;
+            margin-bottom: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🚀 Oragekk's Blog</h1>
+        <div class="subtitle">上冬十二的博客</div>
+
+        <div class="card">
+            <h2>⚠️ 网站需要完成部署配置</h2>
+
+            <div class="warning">
+                <p><strong>当前状态:</strong> 您看到这个页面是因为 GitHub Pages 尚未正确配置。</p>
+            </div>
+
+            <p>这是一个基于 <strong>VuePress 2.x</strong> 的博客项目,需要通过 GitHub Actions 构建后才能正常访问。</p>
+
+            <div class="steps">
+                <div class="step">
+                    <span class="step-number">1</span>
+                    <strong>检查 GitHub Actions 权限</strong>
+                    <p style="margin-top: 0.5rem; margin-left: 2.5rem;">
+                        进入 <code>Settings → Actions → General</code>,确保启用 Actions 并设置为 "Read and write permissions"
+                    </p>
+                </div>
+
+                <div class="step">
+                    <span class="step-number">2</span>
+                    <strong>配置 GitHub Pages</strong>
+                    <p style="margin-top: 0.5rem; margin-left: 2.5rem;">
+                        进入 <code>Settings → Pages</code>,将 Source 设置为 <code>gh-pages</code> 分支
+                    </p>
+                </div>
+
+                <div class="step">
+                    <span class="step-number">3</span>
+                    <strong>触发部署</strong>
+                    <p style="margin-top: 0.5rem; margin-left: 2.5rem;">
+                        进入 <code>Actions</code> 标签页,运行 "部署文档" workflow,或推送代码到 main 分支
+                    </p>
+                </div>
+
+                <div class="step">
+                    <span class="step-number">4</span>
+                    <strong>等待部署完成</strong>
+                    <p style="margin-top: 0.5rem; margin-left: 2.5rem;">
+                        部署通常需要 2-5 分钟,完成后刷新页面即可看到完整的博客网站
+                    </p>
+                </div>
+            </div>
+
+            <div class="success" style="margin-top: 1.5rem;">
+                <p><strong>📖 详细部署指南:</strong> 查看仓库中的 <code>DEPLOY_GUIDE.md</code> 文件获取完整的部署说明和故障排查指南。</p>
+            </div>
+        </div>
+
+        <div class="links">
+            <a href="https://github.com/wuxiansen/wuxiansen.github.io" target="_blank" class="primary-btn">
+                📦 查看源代码
+            </a>
+            <a href="https://github.com/wuxiansen/wuxiansen.github.io/actions" target="_blank">
+                🔄 查看部署状态
+            </a>
+            <a href="https://github.com/wuxiansen/wuxiansen.github.io/blob/main/DEPLOY_GUIDE.md" target="_blank">
+                📖 部署指南
+            </a>
+        </div>
+
+        <div class="footer">
+            <p>基于 VuePress 2.x + VuePress Theme Hope</p>
+            <p>Powered by GitHub Pages</p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## 问题
- 访问 wuxiansen.github.io 显示 README.md 内容
- gh-pages 分支不存在,导致 VuePress 站点无法访问

## 解决方案
1. 添加临时 index.html 页面,提供友好的部署提示
2. 创建详细的 DEPLOY_GUIDE.md 部署指南
3. 指导用户通过 GitHub Actions 完成正确的部署配置

## 变更内容
- ✨ 新增 index.html: 临时欢迎页面,包含部署步骤说明
- ✨ 新增 DEPLOY_GUIDE.md: 完整的部署指南和故障排查文档
- 📝 说明如何配置 GitHub Pages 和触发自动部署
- 📝 提供三种部署方案:自动部署、手动部署、本地部署

## 后续步骤
用户需要:
1. 检查 GitHub Actions 权限配置
2. 配置 GitHub Pages 指向 gh-pages 分支
3. 手动触发一次部署或推送代码到 main 分支
4. 等待部署完成后即可正常访问完整博客