### PR TITLE
Fix missing token input in run job

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.branch.outputs.branch }}
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           submodules: true
 
@@ -74,7 +74,7 @@ jobs:
         with:
           branch: gh-pages
           folder: src/.vuepress/dist
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           clean: true
           single-commit: false
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           # 如果你文档需要 Git 子模块，取消注释下一行
           submodules: true
@@ -43,4 +43,4 @@ jobs:
           # 这是文档部署到的分支名称
           branch: gh-pages
           folder: src/.vuepress/dist
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
将 PAT_TOKEN 替换为 GITHUB_TOKEN 以解决"Input required and not supplied: token"错误。 GITHUB_TOKEN 是 GitHub Actions 自动提供的，无需额外配置。