### PR TITLE
Fix GitHub Pages deployment URL access

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -28,6 +28,10 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - name: 获取分支信息
         id: branch
@@ -77,6 +81,30 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           clean: true
           single-commit: false
+
+      - name: 配置 GitHub Pages 使用 gh-pages 分支
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🔧 配置 GitHub Pages 从 gh-pages 分支部署..."
+
+          # 使用 GitHub API 更新 Pages 配置
+          curl -L \
+            -X PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pages \
+            -d '{"source":{"branch":"gh-pages","path":"/"}}' 2>&1 || \
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pages \
+            -d '{"source":{"branch":"gh-pages","path":"/"}}'
+
+          echo "✅ GitHub Pages 配置完成"
 
       - name: 部署成功通知
         if: success()

--- a/.github/workflows/configure-pages.yml
+++ b/.github/workflows/configure-pages.yml
@@ -1,0 +1,61 @@
+name: 配置 GitHub Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/deploy-docs.yml'
+      - '.github/workflows/configure-pages.yml'
+
+jobs:
+  configure:
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+      contents: read
+    steps:
+      - name: 配置 GitHub Pages 使用 gh-pages 分支
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🔧 配置 GitHub Pages 从 gh-pages 分支部署..."
+
+          # 使用 GitHub API 配置 Pages
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pages \
+            -d '{"source":{"branch":"gh-pages","path":"/"},"build_type":"legacy"}' || true
+
+          # 更新 Pages 配置（如果已存在）
+          curl -L \
+            -X PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pages \
+            -d '{"source":{"branch":"gh-pages","path":"/"}}' || true
+
+          echo "✅ GitHub Pages 配置完成"
+          echo "📝 网站应该可以通过 https://wuxiansen.github.io 访问"
+
+      - name: 等待 Pages 构建完成
+        run: |
+          echo "⏳ 等待 GitHub Pages 构建..."
+          sleep 10
+
+      - name: 显示配置信息
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "📊 当前 GitHub Pages 配置："
+          curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pages

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   deploy-gh-pages:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -44,3 +48,28 @@ jobs:
           branch: gh-pages
           folder: src/.vuepress/dist
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 配置 GitHub Pages 使用 gh-pages 分支
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🔧 配置 GitHub Pages 从 gh-pages 分支部署..."
+
+          # 使用 GitHub API 更新 Pages 配置
+          curl -L \
+            -X PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pages \
+            -d '{"source":{"branch":"gh-pages","path":"/"}}' 2>&1 || \
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pages \
+            -d '{"source":{"branch":"gh-pages","path":"/"}}'
+
+          echo "✅ GitHub Pages 配置完成"
+          echo "📝 网站将通过 https://wuxiansen.github.io 访问"

--- a/GITHUB_PAGES_CONFIG.md
+++ b/GITHUB_PAGES_CONFIG.md
@@ -1,0 +1,54 @@
+# GitHub Pages 配置说明
+
+## 问题描述
+
+访问 https://wuxiansen.github.io 显示的是 README.md 文件内容，而不是编译后的网站内容。
+
+## 原因分析
+
+GitHub Pages 默认配置为从主分支 (main) 的根目录部署，但本项目的编译后内容实际部署在 `gh-pages` 分支。
+
+## 解决方案
+
+### 自动配置 (推荐)
+
+项目现在包含自动配置 GitHub Pages 的工作流：
+
+1. **deploy-docs.yml** - 在每次推送到 main 分支时自动部署并配置 Pages
+2. **auto-deploy.yml** - 手动触发部署时也会自动配置 Pages
+3. **configure-pages.yml** - 单独的配置工作流，可手动触发
+
+这些工作流会自动将 GitHub Pages 配置为从 `gh-pages` 分支部署。
+
+### 手动配置 (备选)
+
+如果自动配置失败，你也可以手动配置：
+
+1. 访问仓库设置页面：https://github.com/wuxiansen/wuxiansen.github.io/settings/pages
+2. 在 "Build and deployment" 部分
+3. 在 "Source" 下拉菜单中选择 "Deploy from a branch"
+4. 在 "Branch" 下拉菜单中选择 `gh-pages` 分支和 `/ (root)` 目录
+5. 点击 "Save" 保存配置
+
+## 部署流程
+
+```mermaid
+graph LR
+    A[推送到 main 分支] --> B[触发 deploy-docs 工作流]
+    B --> C[安装依赖]
+    C --> D[构建 VuePress]
+    D --> E[部署到 gh-pages 分支]
+    E --> F[配置 GitHub Pages]
+    F --> G[网站可通过 wuxiansen.github.io 访问]
+```
+
+## 验证
+
+配置完成后，访问 https://wuxiansen.github.io 应该能看到编译后的网站内容，而不是 README.md。
+
+## 注意事项
+
+- 编译后的内容存储在 `gh-pages` 分支
+- 源代码在 `main` 分支
+- 不要直接修改 `gh-pages` 分支，它由 GitHub Actions 自动管理
+- 网站更新需要推送到 `main` 分支，触发自动构建和部署


### PR DESCRIPTION
解决访问 https://wuxiansen.github.io 显示 README.md 而不是编译后网站内容的问题。

主要更改：
- 更新 deploy-docs.yml 工作流，添加自动配置 GitHub Pages 的步骤
- 更新 auto-deploy.yml 工作流，添加自动配置 GitHub Pages 的步骤
- 新增 configure-pages.yml 工作流，支持单独配置 GitHub Pages
- 添加 GITHUB_PAGES_CONFIG.md 说明文档

这些工作流会自动将 GitHub Pages 配置为从 gh-pages 分支部署，
确保 https://wuxiansen.github.io 能正确显示编译后的网站内容。